### PR TITLE
Xenial - do not managae service file and let the service provider auto-detect

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,13 @@ class etcd::params {
   # Service settings
   $etcd_service_ensure          = 'running'
   $etcd_service_enable          = true
-  $etcd_manage_service_file     = true
+
+  # Ubuntu xenial contains valid systemd service config #
+  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '16') >= 0 {
+    $etcd_manage_service_file     = true
+  } else {
+    $etcd_manage_service_file     = false
+  }
 
   # Package settings
   $etcd_package_ensure          = 'installed'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,7 +13,14 @@ class etcd::service {
       $service_file_location = '/etc/init/etcd.conf'
       $service_file_contents = template('etcd/etcd.upstart.erb')
       $service_file_mode     = '0444'
-      $service_provider      = 'upstart'
+
+      # Ubuntu xenial contains valid systemd service config #
+      if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '16') >= 0 {
+        $service_provider      = undef
+      } else {
+        $service_provider      = 'upstart'
+      }
+
     }
     default  : {
       fail("OSFamily ${::osfamily} not supported.")


### PR DESCRIPTION
The etcd package in xenial has a service file for systemd, and obviously the provider is no longer upstart :)